### PR TITLE
Support message value verification with HMAC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "ssb-verify-signatures"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Piet Geursen <pietgeursen@gmail.com>"]
 description = "Verify signatures of scuttlebutt messages. In parallel."
 edition = "2018"
 license = "AGPL-3.0"
-
 
 [dependencies]
 arrayvec = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 snafu = "0.6.10"
+ssb-crypto = "0.2.2"
 ssb-legacy-msg-data = "0.1.2" 
 rand = "0.8.3"
 rayon = "1.5.1"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-[![Build Status](https://travis-ci.org/sunrise-choir/ssb-verify-signatures.svg?branch=master)](https://travis-ci.org/sunrise-choir/ssb-verify-signatures)
 # ssb-verify-signatures
 
-> Verify Secure Scuttlebutt message signatures (in parallel)
+[![Build Status](https://travis-ci.org/sunrise-choir/ssb-verify-signatures.svg?branch=master)](https://travis-ci.org/sunrise-choir/ssb-verify-signatures) [![Documentation badge](https://img.shields.io/badge/rust-docs-blue)](https://sunrise-choir.github.io/ssb-verify-signatures/ssb_verify_signatures/index.html)
 
-## Docs
-
-[Rustdocs](https://sunrise-choir.github.io/ssb-verify-signatures/ssb_verify_signatures/index.html)
+Verify Secure Scuttlebutt message signatures (in parallel)/
 
 ## How is this different to [ssb-legacy-msg](https://github.com/sunrise-choir/ssb-legacy-msg)?
 
@@ -17,6 +14,14 @@ Batch processing is good for two reasons:
 - it means we can use the [ed25519_dalek verify_batch](https://docs.rs/ed25519-dalek/0.9.1/ed25519_dalek/fn.verify_batch.html) function that takes advantage of
 processor SIMD instructions. 
 
+## Benchmarks
+
 Benchmarking on a 2016 2 core i5 shows that batch processing with `par_verify_messages` is ~3.6 times faster than using `verify_message` 
 
-Benchmarking on Android on a [One Plus 5T](https://en.wikipedia.org/wiki/OnePlus_5T) (8 core arm64) shows that batch processing with `par_verify_messages` is ~9.9 times faster than using `verify_message`! 
+Benchmarking on Android on a [One Plus 5T](https://en.wikipedia.org/wiki/OnePlus_5T) (8 core arm64) shows that batch processing with `par_verify_messages` is ~9.9 times faster than using `verify_message`!
+
+Benchmarks can be run with `cargo criterion`.
+
+## License
+
+AGPL-3.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use ssb_crypto::{AsBytes, NetworkKey};
 use ssb_legacy_msg_data::json::{from_slice, to_string, DecodeJsonError, EncodeJsonError};
 use ssb_legacy_msg_data::value::Value;
+use std::convert::TryInto;
 
 use ed25519_dalek::{verify_batch as dalek_verify_batch, PublicKey, Signature, Verifier};
 
@@ -118,7 +119,7 @@ pub fn verify_message<T: AsRef<[u8]>>(msg: T) -> Result<()> {
         .context(InvalidSignature)
 }
 
-/// Verify the signature of a ssb `message.value`.
+/// Verify the signature of a ssb `message.value` with an optional HMAC key.
 ///
 /// It expects the messages to be the JSON encoded message value of shape: `{
 /// previous: "",
@@ -128,6 +129,9 @@ pub fn verify_message<T: AsRef<[u8]>>(msg: T) -> Result<()> {
 /// content: {},
 /// signature: ""
 /// }`
+///
+/// You may pass an `Option<&[u8]>` for `hmac`. If `None`, the message value is verified without
+/// first generating an HMAC authentication tag.
 ///
 /// Returns `Ok(())` if the signature did sign this message, otherwise `Err(InvalidSignature)`
 ///
@@ -148,131 +152,32 @@ pub fn verify_message<T: AsRef<[u8]>>(msg: T) -> Result<()> {
 ///  },
 ///  "signature": "PkZ34BRVSmGG51vMXo4GvaoS/2NBc0lzdFoVv4wkI8E8zXv4QYyE5o2mPACKOcrhrLJpymLzqpoE70q78INuBg==.sig.ed25519"
 ///}"##;
-/// let result = verify_message_value(valid_message_value.as_bytes());
+/// let result = verify_message_value(valid_message_value.as_bytes(), None);
 /// assert!(result.is_ok());
 ///```
-pub fn verify_message_value<T: AsRef<[u8]>>(msg: T) -> Result<()> {
+pub fn verify_message_value<T: AsRef<[u8]>>(msg: T, hmac: Option<&[u8]>) -> Result<()> {
     let (key, sig, bytes) = get_pubkey_sig_bytes_from_ssb_message_value(msg.as_ref())?;
-    key.verify(&bytes, &sig)
-        .map_err(|_| snafu::NoneError)
-        .context(InvalidSignature)
-}
-
-/// Verify the signature of a ssb `message.value` with the given hmac key (also known as the
-/// 'app key', 'SHS key', 'capabilities key' and 'network identifier').
-///
-/// It expects the messages to be the JSON encoded message value of shape: `{
-/// previous: "",
-/// author: "",
-/// sequence: ...,
-/// timestamp: ...,
-/// content: {},
-/// signature: ""
-/// }`
-///
-/// Returns `Ok(())` if the signature did sign this message, otherwise `Err(InvalidSignature)`
-///
-/// # Example
-/// ```
-/// use ssb_verify_signatures::verify_message_value_with_hmac;
-/// let valid_message_value_with_unique_hmac = r##"{
-///  "previous": null,
-///  "sequence": 1,
-///  "author": "@EnPSnV1HZdyE7pcKxqukyhmnwE9076RtAlYclaUMX5g=.ed25519",
-///  "timestamp": 1624360181359,
-///  "hash": "sha256",
-///  "content": {
-///    "type": "example"
-///  },
-///  "signature": "w670wqnD1A5blFaYxDiIhPOTwz8I7syVx30jac1feQK/OywHFfrcLVw2S1KmxK9GzWxvKxLMle/jKjf2+pHtAg==.sig.ed25519"
-/// }"##;
-/// let msg_bytes = valid_message_value_with_unique_hmac.as_bytes();
-/// // this represents the unique hmac the message value was originally signed with
-/// let hmac = base64::decode("CbwuwYXmZgN7ZSuycCXoKGOTU1dGwBex+paeA2kr37U=").unwrap();
-/// let result = verify_message_value_with_hmac(&msg_bytes, &hmac);
-/// assert!(result.is_ok());
-/// ```
-pub fn verify_message_value_with_hmac<T: AsRef<[u8]>>(msg: T, hmac: &[u8]) -> Result<()> {
-    let (key, sig, bytes) = get_pubkey_sig_bytes_from_ssb_message_value(msg.as_ref())?;
-    // deserialize hmac from given byte slice, returns `None` if the slice length isn't 32
-    let hmac_key = NetworkKey::from_slice(hmac).context(InvalidHmac)?;
-    // generate hmac auth tag from msg bytes
-    let tag = hmac_key.authenticate(&bytes);
-    let tag_bytes = tag.as_bytes();
-    // verify using key, tag and signature
-    key.verify(tag_bytes, &sig)
-        .map_err(|_| snafu::NoneError)
-        .context(InvalidSignature)
+    match hmac {
+        Some(hmac_bytes) => {
+            // deserialize hmac from given byte slice (returns `None` if length != 32)
+            let hmac_key = NetworkKey::from_slice(hmac_bytes).context(InvalidHmac)?;
+            // compute hmac auth tag from msg bytes
+            let tag = hmac_key.authenticate(&bytes);
+            let tag_bytes = tag.as_bytes();
+            key.verify(tag_bytes, &sig)
+                .map_err(|_| snafu::NoneError)
+                .context(InvalidSignature)
+        }
+        None => key
+            .verify(&bytes, &sig)
+            .map_err(|_| snafu::NoneError)
+            .context(InvalidSignature),
+    }
 }
 
 pub const CHUNK_SIZE: usize = 50;
 
-pub fn par_verify_message_values_with_hmac<T: AsRef<[u8]>>(
-    msgs: &[T],
-    hmac: &[u8],
-    chunk_size: Option<usize>,
-) -> Result<()>
-where
-    [T]: ParallelSlice<T>,
-    T: Sync,
-{
-    par_verify_with_hmac(
-        msgs,
-        hmac,
-        chunk_size,
-        get_pubkey_sig_bytes_from_ssb_message_value,
-    )
-}
-
-fn par_verify_with_hmac<T: AsRef<[u8]>, M: Fn(&[u8]) -> Result<KeySigBytes>>(
-    msgs: &[T],
-    hmac: &[u8],
-    chunk_size: Option<usize>,
-    mapper: M,
-) -> Result<()>
-where
-    [T]: ParallelSlice<T>,
-    T: Sync,
-    M: Sync,
-{
-    let hmac_key = NetworkKey::from_slice(hmac).context(InvalidHmac)?;
-
-    msgs.as_parallel_slice()
-        .par_chunks(chunk_size.unwrap_or(CHUNK_SIZE))
-        .try_fold(
-            || (),
-            |_, chunk| {
-                let keys_sigs_bytes = chunk
-                    .iter()
-                    .map(|msg| mapper(msg.as_ref()))
-                    .collect::<Result<ArrayVec<[KeySigBytes; CHUNK_SIZE]>>>()?;
-
-                //each chunk is a collection of (key, sig, bytes)
-                let keys = keys_sigs_bytes
-                    .iter()
-                    .map(|(key, _, _)| *key)
-                    .collect::<ArrayVec<[_; CHUNK_SIZE]>>();
-                let sigs = keys_sigs_bytes
-                    .iter()
-                    .map(|(_, sig, _)| *sig)
-                    .collect::<ArrayVec<[_; CHUNK_SIZE]>>();
-                let bytes = keys_sigs_bytes
-                    .iter()
-                    .map(|(_, _, msg)| msg.as_slice())
-                    // TODO: handle the unwrap
-                    .map(|msg| get_hmac_tag_bytes(&hmac_key, msg).unwrap())
-                    .map(|tag| &tag)
-                    .collect::<ArrayVec<[_; CHUNK_SIZE]>>();
-
-                dalek_verify_batch(bytes.as_slice(), sigs.as_slice(), keys.as_slice())
-                    .map_err(|_| snafu::NoneError)
-                    .context(InvalidSignature)
-            },
-        )
-        .try_reduce(|| (), |_, _| Ok(()))
-}
-
-/// Checks signatures of a slice of message values in parallel.
+/// Checks signatures of a slice of message values in parallel with an optional HMAC key.
 ///
 /// It expects the messages to be the JSON encoded message value of shape: `{
 /// previous: "",
@@ -285,6 +190,9 @@ where
 ///
 /// Uses `ed25519_dalek`'s batch verify method to take advantage of processors with SIMD
 /// instructions, and process them in parallel using `rayon`.
+///
+/// You may pass an `Option<&[u8]>` for `hmac`. If `None`, the message values are verified without
+/// first generating an HMAC authentication tag.
 ///
 /// You may pass an `Option<usize>` for `chunk_size` or, if `None`, a default of [CHUNK_SIZE] is used.
 ///
@@ -310,11 +218,12 @@ where
 ///  "signature": "PkZ34BRVSmGG51vMXo4GvaoS/2NBc0lzdFoVv4wkI8E8zXv4QYyE5o2mPACKOcrhrLJpymLzqpoE70q78INuBg==.sig.ed25519"
 ///}"##.as_bytes();
 /// let values = [valid_message_value, valid_message_value, valid_message_value];
-/// let result = par_verify_message_values(&values, None);
+/// let result = par_verify_message_values(&values, None, None);
 /// assert!(result.is_ok());
 ///```
 pub fn par_verify_message_values<T: AsRef<[u8]>>(
     msgs: &[T],
+    hmac: Option<&[u8]>,
     chunk_size: Option<usize>,
 ) -> Result<()>
 where
@@ -323,6 +232,7 @@ where
 {
     par_verify(
         msgs,
+        hmac,
         chunk_size,
         get_pubkey_sig_bytes_from_ssb_message_value,
     )
@@ -371,11 +281,17 @@ where
     [T]: ParallelSlice<T>,
     T: Sync,
 {
-    par_verify(msgs, chunk_size, get_pubkey_sig_bytes_from_ssb_message)
+    par_verify(
+        msgs,
+        None,
+        chunk_size,
+        get_pubkey_sig_bytes_from_ssb_message,
+    )
 }
 
 fn par_verify<T: AsRef<[u8]>, M: Fn(&[u8]) -> Result<KeySigBytes>>(
     msgs: &[T],
+    hmac: Option<&[u8]>,
     chunk_size: Option<usize>,
     mapper: M,
 ) -> Result<()>
@@ -384,6 +300,8 @@ where
     T: Sync,
     M: Sync,
 {
+    let hmac_key = hmac.map(|hmac| NetworkKey::from_slice(hmac)).flatten();
+
     msgs.as_parallel_slice()
         .par_chunks(chunk_size.unwrap_or(CHUNK_SIZE))
         .try_fold(
@@ -403,14 +321,32 @@ where
                     .iter()
                     .map(|(_, sig, _)| *sig)
                     .collect::<ArrayVec<[_; CHUNK_SIZE]>>();
-                let bytes = keys_sigs_bytes
-                    .iter()
-                    .map(|(_, _, msg)| msg.as_slice())
-                    .collect::<ArrayVec<[_; CHUNK_SIZE]>>();
+                match &hmac_key {
+                    Some(hmac_bytes) => {
+                        let tag_arrays = keys_sigs_bytes
+                            .iter()
+                            .map(|(_, _, msg)| get_hmac_tag_bytes(hmac_bytes, msg))
+                            .collect::<ArrayVec<[[u8; 32]; CHUNK_SIZE]>>();
+                        let tag_bytes = tag_arrays
+                            .iter()
+                            .map(|array| &array[..])
+                            .collect::<ArrayVec<[&[u8]; CHUNK_SIZE]>>();
 
-                dalek_verify_batch(bytes.as_slice(), sigs.as_slice(), keys.as_slice())
-                    .map_err(|_| snafu::NoneError)
-                    .context(InvalidSignature)
+                        dalek_verify_batch(tag_bytes.as_slice(), sigs.as_slice(), keys.as_slice())
+                            .map_err(|_| snafu::NoneError)
+                            .context(InvalidSignature)
+                    }
+                    None => {
+                        let msg_bytes = keys_sigs_bytes
+                            .iter()
+                            .map(|(_, _, msg)| msg.as_slice())
+                            .collect::<ArrayVec<[_; CHUNK_SIZE]>>();
+
+                        dalek_verify_batch(msg_bytes.as_slice(), sigs.as_slice(), keys.as_slice())
+                            .map_err(|_| snafu::NoneError)
+                            .context(InvalidSignature)
+                    }
+                }
             },
         )
         .try_reduce(|| (), |_, _| Ok(()))
@@ -489,21 +425,22 @@ fn get_key_bytes(key: &[u8]) -> Result<[u8; 32]> {
     Ok(buff)
 }
 
-fn get_hmac_tag_bytes(hmac: &NetworkKey, msg: &[u8]) -> Result<[u8; 32]> {
-    let tag = hmac.authenticate(&msg);
+fn get_hmac_tag_bytes(hmac: &NetworkKey, msg: &[u8]) -> [u8; 32] {
+    let tag = hmac.authenticate(msg);
     let tag_bytes = tag.as_bytes();
-    let mut buff = [0; 32];
-    decode_config_slice(tag_bytes, base64::STANDARD, &mut buff)
-        .context(InvalidAuthorStringBase64Encoding)?;
-    Ok(buff)
+    let bytes: [u8; 32] = tag_bytes
+        .try_into()
+        // this should never panic, since `.authenticate()` returns a 32 byte tag
+        .expect("tag slice with incorrect length");
+    bytes
 }
 
 #[cfg(test)]
 mod tests {
 
     use crate::{
-        get_key_bytes, get_sig_bytes, par_verify_message_values, par_verify_messages,
-        verify_message, verify_message_value, verify_message_value_with_hmac, Error,
+        get_hmac_tag_bytes, get_key_bytes, get_sig_bytes, par_verify_message_values,
+        par_verify_messages, verify_message, verify_message_value, Error,
     };
     use base64;
     use ssb_crypto::{AsBytes, NetworkKey};
@@ -516,7 +453,7 @@ mod tests {
     #[test]
     fn verify_message_value_works() {
         let msg = VALID_MESSAGE_VALUE.as_bytes();
-        assert!(verify_message_value(&msg).is_ok());
+        assert!(verify_message_value(&msg, None).is_ok());
     }
 
     #[test]
@@ -530,13 +467,13 @@ mod tests {
         assert!(result.is_ok());
     }
     #[test]
-    fn par_verify_messages_values_works() {
+    fn par_verify_message_values_works() {
         let msgs = [
             VALID_MESSAGE_VALUE.as_bytes(),
             VALID_MESSAGE_VALUE.as_bytes(),
             VALID_MESSAGE_VALUE.as_bytes(),
         ];
-        let result = par_verify_message_values(&msgs, None);
+        let result = par_verify_message_values(&msgs, None, None);
         assert!(result.is_ok());
     }
     #[test]
@@ -570,10 +507,22 @@ mod tests {
     }
 
     #[test]
-    fn verify_message_value_with_hmac_works() {
+    fn get_hmac_tag_bytes_works() {
+        let hmac = NetworkKey::SSB_MAIN_NET;
+        let msg = VALID_MESSAGE_VALUE.as_bytes();
+        let expected: [u8; 32] = [
+            117, 255, 113, 86, 0, 193, 174, 22, 28, 244, 68, 210, 10, 122, 167, 66, 9, 201, 131,
+            82, 209, 18, 224, 236, 245, 11, 160, 247, 62, 77, 39, 249,
+        ];
+        let bytes = get_hmac_tag_bytes(&hmac, msg);
+        assert_eq!(&bytes[..], &expected[..]);
+    }
+
+    #[test]
+    fn verify_message_value_with_unique_hmac_works() {
         let msg = VALID_MESSAGE_VALUE_UNIQUE_HMAC.as_bytes();
         let hmac = base64::decode("CbwuwYXmZgN7ZSuycCXoKGOTU1dGwBex+paeA2kr37U=").unwrap();
-        let result = verify_message_value_with_hmac(&msg, &hmac);
+        let result = verify_message_value(&msg, Some(&hmac));
         assert!(result.is_ok());
     }
 
@@ -582,11 +531,36 @@ mod tests {
         let msg = VALID_MESSAGE_VALUE_UNIQUE_HMAC.as_bytes();
         let hmac = NetworkKey::SSB_MAIN_NET;
         let hmac_bytes = hmac.as_bytes();
-        let result = verify_message_value_with_hmac(&msg, &hmac_bytes);
+        let result = verify_message_value(&msg, Some(&hmac_bytes));
         match result {
             Err(Error::InvalidSignature {}) => {}
             _ => panic!(),
         }
+    }
+
+    #[test]
+    fn verify_message_value_with_invalid_hmac_fails() {
+        let msg = VALID_MESSAGE_VALUE_UNIQUE_HMAC.as_bytes();
+        // this hmac is not valid base64
+        let hmac = "OTU1dGwBexpaeA2kr37U".to_string();
+        let hmac_bytes = hmac.as_bytes();
+        let result = verify_message_value(&msg, Some(&hmac_bytes));
+        match result {
+            Err(Error::InvalidHmac {}) => {}
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn par_verify_message_values_with_hmac_works() {
+        let msgs = [
+            VALID_MESSAGE_VALUE_UNIQUE_HMAC.as_bytes(),
+            VALID_MESSAGE_VALUE_UNIQUE_HMAC.as_bytes(),
+            VALID_MESSAGE_VALUE_UNIQUE_HMAC.as_bytes(),
+        ];
+        let hmac = base64::decode("CbwuwYXmZgN7ZSuycCXoKGOTU1dGwBex+paeA2kr37U=").unwrap();
+        let result = par_verify_message_values(&msgs, Some(&hmac), None);
+        assert!(result.is_ok());
     }
 
     const VALID_MESSAGE: &str = r##"{
@@ -607,6 +581,7 @@ mod tests {
   },
   "timestamp": 1571140551543
 }"##;
+
     const VALID_MESSAGE_VALUE: &str = r##"{
   "previous": "%IIjwbJbV3WBE/SBLnXEv5XM3Pr+PnMkrAJ8F+7TsUVQ=.sha256",
   "author": "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519",
@@ -621,6 +596,7 @@ mod tests {
   },
   "signature": "PkZ34BRVSmGG51vMXo4GvaoS/2NBc0lzdFoVv4wkI8E8zXv4QYyE5o2mPACKOcrhrLJpymLzqpoE70q78INuBg==.sig.ed25519"
 }"##;
+
     const INVALID_MESSAGE: &str = r##"{
   "key": "%kmXb3MXtBJaNugcEL/Q7G40DgcAkMNTj3yhmxKHjfCM=.sha256",
   "value": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,6 @@ fn get_hmac_tag_bytes(hmac: &NetworkKey, msg: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-
     use crate::{
         get_hmac_tag_bytes, get_key_bytes, get_sig_bytes, par_verify_message_values,
         par_verify_messages, verify_message, verify_message_value, Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ where
 }
 
 fn get_pubkey_sig_bytes_from_ssb_message_value(msg: &[u8]) -> Result<KeySigBytes> {
-    let mut verifiable_msg: Value = from_slice(&msg).context(InvalidSsbMessage)?;
+    let mut verifiable_msg: Value = from_slice(msg).context(InvalidSsbMessage)?;
     let message_value: SsbMessageValue =
         serde_json::from_slice(msg).context(InvalidSsbMessageJson)?;
 
@@ -361,7 +361,7 @@ fn get_pubkey_sig_bytes_from_ssb_message_value(msg: &[u8]) -> Result<KeySigBytes
 }
 
 fn get_pubkey_sig_bytes_from_ssb_message(msg: &[u8]) -> Result<KeySigBytes> {
-    let message_value: Value = from_slice(&msg).context(InvalidSsbMessage)?;
+    let message_value: Value = from_slice(msg).context(InvalidSsbMessage)?;
     let message: SsbMessage = serde_json::from_slice(msg).context(InvalidSsbMessageJson)?;
 
     let mut verifiable_msg = if let Value::Object(kv) = message_value {


### PR DESCRIPTION
This PR adds an optional HMAC key argument to the message value verification functions, as well as the core parallel verification function. Message verification functions (accepting `KVT` messages) remain as they were (`hmac` is set to `None` where required).

The HMAC is expected to be of type `Option<&[u8]>`.

A helper function has been added to assist with HMAC verification:

`get_hmac_tag_bytes(hmac: &NetworkKey, msg: &[u8]) -> [u8; 32]`

Tests, doc comments, doc tests and benchmarks have been updated and are all passing. Version has been bumped to `1.2.0`.

Hat-tip to @sbillig for assisting with debugging.

Further context here: https://github.com/sunrise-choir/ssb-verify-signatures/issues/3
Addresses https://github.com/ssb-ngi-pointer/ssb-validate2-rsjs/issues/25